### PR TITLE
Fix link to dependency

### DIFF
--- a/src/extension/chromium/contentscript.js
+++ b/src/extension/chromium/contentscript.js
@@ -9,7 +9,7 @@ s.src = chrome.extension.getURL('resources/jquery-79df507d65fd38a3fb7d06c48c670c
 document.head.appendChild(s);
 
 s = document.createElement('script');
-s.src = chrome.extension.getURL('resources/owl-globals-239ae89a2c9995e21675bb37d0a1a3cb.js');
+s.src = chrome.extension.getURL('resources/owl-globals-33312482ebc39a1659e8bfff0033770d.js');
 document.head.appendChild(s);
 
 s = document.createElement('script');


### PR DESCRIPTION
Webpack already refers to this new `owl-globals-...` file, but it was not correctly pulled,
and thus there's a mismatch between the file the extension ships and tries to use.

See current master:
https://github.com/petrosagg/papagal/blob/62ef12c9b9685e9bf267cd86827e26acc7bd1343/webpack.config.js#L26

Fixes: #4 
Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>